### PR TITLE
[Feat] #20 - entity 수정에 맞게 book crud, entity추가 수정 및 최근 아이가 본 도서목록 추가

### DIFF
--- a/src/main/java/com/mycom/myapp/naviya/domain/book/controller/BookController.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/controller/BookController.java
@@ -2,9 +2,10 @@ package com.mycom.myapp.naviya.domain.book.controller;
 
 import com.mycom.myapp.naviya.domain.book.dto.BookResultDto;
 //import com.mycom.myapp.naviya.domain.book.service.BookServiceImpl;
+import com.mycom.myapp.naviya.domain.book.service.BookServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-/*
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/Book")
@@ -30,9 +31,19 @@ public class BookController {
     {
         return bookServiceImpl.listBookChildFavor(childId);
     }
+    @GetMapping("/ListBookChildRecntRead")
+    public BookResultDto ListBookChildRecntRead(@RequestParam long childId)
+    {
+        return bookServiceImpl.listBookChildRecntRead(childId);
+    }
     @DeleteMapping("/BookDel")
     public BookResultDto DeleteBook(@RequestParam long bookId)
     {
         return bookServiceImpl.delBook(bookId);
     }
-}*/
+    @GetMapping("/BookDetail")
+    public BookResultDto DetailBook(@RequestParam long bookId)
+    {
+        return bookServiceImpl.detailBook(bookId);
+    }
+}

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/dto/BookDto.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/dto/BookDto.java
@@ -2,12 +2,18 @@ package com.mycom.myapp.naviya.domain.book.dto;
 
 import com.mycom.myapp.naviya.domain.book.entity.UserRecentBooks;
 import com.mycom.myapp.naviya.domain.child.entity.ChildBookLike;
+import com.mycom.myapp.naviya.global.mbti.Dto.MbtiDto;
+import com.mycom.myapp.naviya.global.mbti.Mbti_Name;
 import com.mycom.myapp.naviya.global.mbti.entity.Mbti;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 import java.util.List;
+@NoArgsConstructor
+@AllArgsConstructor
 @Data
 public class BookDto {
     private Long bookId;
@@ -20,5 +26,23 @@ public class BookDto {
     private String fullStory;
     private byte[] bookImage;
     private String category;
-    private Mbti bookMbti;
+    private MbtiDto bookMbti;
+    private BookFavorTotalDto booktotalfavor;
+  /*  public BookDto() {}
+    public BookDto(Long bookId, String title, String summary, String recommendedAge, String publisher, String author,
+                   Timestamp createdAt, String fullStory, byte[] bookImage, String categoryCode, MbtiDto bookMbti,
+                   Long booktotalfavor) {
+        this.bookId = bookId;
+        this.title = title;
+        this.summary = summary;
+        this.recommendedAge = recommendedAge;
+        this.publisher = publisher;
+        this.author = author;
+        this.createdAt = createdAt;
+        this.fullStory = fullStory;
+        this.bookImage = bookImage;
+        this.category = categoryCode;
+        this.bookMbti = bookMbti;
+        this.booktotalfavor = booktotalfavor;
+    }*/
 }

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/dto/BookFavorTotalDto.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/dto/BookFavorTotalDto.java
@@ -1,0 +1,14 @@
+package com.mycom.myapp.naviya.domain.book.dto;
+
+import com.mycom.myapp.naviya.domain.book.entity.Book;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class BookFavorTotalDto {
+    private Long count;
+}

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/entity/Book.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/entity/Book.java
@@ -42,10 +42,12 @@ public class Book {
     @Column(name = "category_code")
     private String categoryCode;
 
-    @OneToOne(mappedBy = "book")
+    @OneToOne(cascade =CascadeType.ALL ,mappedBy = "book")
     private UserRecentBooks userRecentBooks;
     @OneToOne(cascade = CascadeType.ALL,mappedBy = "book")
     private ChildBookLike childBookLike;
+
+
     @OneToOne(cascade =CascadeType.ALL ,mappedBy = "book")
     private BookMbti bookMbti;
 

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/entity/BookFavorTotal.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/entity/BookFavorTotal.java
@@ -1,8 +1,10 @@
 package com.mycom.myapp.naviya.domain.book.entity;
 
 import jakarta.persistence.*;
+import lombok.Data;
 
 @Entity
+@Data
 @Table(name = "book_favor_total")
 public class BookFavorTotal {
 

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/entity/BookMbti.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/entity/BookMbti.java
@@ -7,16 +7,24 @@ import lombok.Data;
 @Data
 @Entity
 @Table(name = "BookMbti")
+/*
+Book (부모)↔ BookMbti (자식)BookMbti↔ Mbti (부모)
+ book에  cascaed ->bookmbti 자식에서 -> mbti에게 cascaed으로
+일대일 양방향에서 자식이 부모에게 casecaed 걸 수 있음
+기술적으로 가능은함
+우리는 일부로 childmbti와 bookmbti를 동시에 사용하기 때문에 자식에게 casecade를 걸어도 무방
+*/
 public class BookMbti {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "bookmbti_id")
     private Long bookMbtiId;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
-    @OneToOne
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "mbti_id", nullable = false)
     private Mbti mbti;
 }

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/entity/UserRecentBooks.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/entity/UserRecentBooks.java
@@ -20,7 +20,7 @@ public class UserRecentBooks {
     @JoinColumn(name = "child_id", nullable = false)
     private Child child;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)   
     @JoinColumn(name="book_id")
     private Book book;
 

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/repository/BookFavorTotalRepository.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/repository/BookFavorTotalRepository.java
@@ -1,0 +1,13 @@
+package com.mycom.myapp.naviya.domain.book.repository;
+
+import com.mycom.myapp.naviya.domain.book.entity.BookFavorTotal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BookFavorTotalRepository extends JpaRepository<BookFavorTotal, Long> {
+    BookFavorTotal findByBook_BookId(Long bookId);
+
+}

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/repository/BookMbtiRepository.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/repository/BookMbtiRepository.java
@@ -4,11 +4,16 @@ import com.mycom.myapp.naviya.domain.book.entity.Book;
 import com.mycom.myapp.naviya.domain.book.entity.BookMbti;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
-/*
+import java.util.Optional;
+
+@Repository
 public interface BookMbtiRepository extends JpaRepository<BookMbti, Long> {
 
     //@Query("SELECT b.mbti FROM BookMbti b WHERE b.book.bookId = :bookId")
     //List<Mbti> findMbtiByBookId(@Param("bookId") Long bookId);
-}*/
+
+    BookMbti findByBook_BookId(Long bookId);
+}

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/repository/BookRepository.java
@@ -1,13 +1,94 @@
 package com.mycom.myapp.naviya.domain.book.repository;
 
+import com.mycom.myapp.naviya.domain.book.dto.BookDto;
 import com.mycom.myapp.naviya.domain.book.entity.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import com.mycom.myapp.naviya.global.mbti.Dto.MbtiDto;
 import java.util.List;
-/*
+@Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
-    List<Book> findAllByOrderByCreateDateDesc();
-    List<Book> findAllByOrderByCreateDateAsc();
-    List<Book> findAllByOrderByCountDesc();
-}*/
+
+    @Query("SELECT new com.mycom.myapp.naviya.domain.book.dto.BookDto(b.bookId, " +
+            "b.title, b.summary, b.recommendedAge, b.publisher, b.author, " +
+            "b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "new com.mycom.myapp.naviya.global.mbti.Dto.MbtiDto(m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType), " +
+            "new com.mycom.myapp.naviya.domain.book.dto.BookFavorTotalDto(f.count)) " + // 수정된 부분
+            "FROM Book b " +
+            "LEFT JOIN b.bookMbti bm " +
+            "LEFT JOIN bm.mbti m " +
+            "LEFT JOIN BookFavorTotal f ON f.book.bookId = b.bookId " +
+            "GROUP BY b.bookId, b.title, b.summary, b.recommendedAge, b.publisher, " +
+            "b.author, b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType,f.count")
+    List<BookDto> findAllBookDto();
+    Book findBybookId(Long bookId);
+
+    @Query("SELECT new com.mycom.myapp.naviya.domain.book.dto.BookDto(b.bookId, " +
+            "b.title, b.summary, b.recommendedAge, b.publisher, b.author, " +
+            "b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "new com.mycom.myapp.naviya.global.mbti.Dto.MbtiDto(m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType), " +
+            "new com.mycom.myapp.naviya.domain.book.dto.BookFavorTotalDto(f.count)) " +
+            "FROM Book b " +
+            "LEFT JOIN b.bookMbti bm " +
+            "LEFT JOIN bm.mbti m " +
+            "LEFT JOIN BookFavorTotal f ON f.book.bookId = b.bookId " +
+            "GROUP BY b.bookId, b.title, b.summary, b.recommendedAge, b.publisher, " +
+            "b.author, b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType, f.count " +
+            "ORDER BY b.createdAt ASC")  // createdAt 기준 오름차순 정렬
+    List<BookDto> findBookDtoDescCreateDate();
+
+    @Query("SELECT new com.mycom.myapp.naviya.domain.book.dto.BookDto(b.bookId, " +
+            "b.title, b.summary, b.recommendedAge, b.publisher, b.author, " +
+            "b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "new com.mycom.myapp.naviya.global.mbti.Dto.MbtiDto(m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType), " +
+            "new com.mycom.myapp.naviya.domain.book.dto.BookFavorTotalDto(f.count)) " +
+            "FROM Book b " +
+            "LEFT JOIN b.bookMbti bm " +
+            "LEFT JOIN bm.mbti m " +
+            "LEFT JOIN BookFavorTotal f ON f.book.bookId = b.bookId " +
+            "GROUP BY b.bookId, b.title, b.summary, b.recommendedAge, b.publisher, " +
+            "b.author, b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType, f.count " +
+            "ORDER BY f.count DESC")  // f.count 기준 내림차순 정렬
+    List<BookDto> findBookDescBookFavor();
+
+    @Query("SELECT new com.mycom.myapp.naviya.domain.book.dto.BookDto(b.bookId, " +
+            "b.title, b.summary, b.recommendedAge, b.publisher, b.author, " +
+            "b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "new com.mycom.myapp.naviya.global.mbti.Dto.MbtiDto(m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType), " +
+            "new com.mycom.myapp.naviya.domain.book.dto.BookFavorTotalDto(f.count)) " +
+            "FROM ChildBookLike cbl " +
+            "JOIN cbl.book b " +
+            "LEFT JOIN b.bookMbti bm " +
+            "LEFT JOIN bm.mbti m " +
+            "LEFT JOIN BookFavorTotal f ON f.book.bookId = b.bookId " +
+            "WHERE cbl.child.childId = :childId " +
+            "AND cbl.DelDate IS NULL " +
+            "GROUP BY b.bookId, b.title, b.summary, b.recommendedAge, b.publisher, " +
+            "b.author, b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType, f.count " +
+            "ORDER BY b.createdAt DESC")
+
+    List<BookDto> findBooksByChildId(@Param("childId") Long childId);
+
+    @Query("SELECT new com.mycom.myapp.naviya.domain.book.dto.BookDto(b.bookId, " +
+            "b.title, b.summary, b.recommendedAge, b.publisher, b.author, " +
+            "b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "new com.mycom.myapp.naviya.global.mbti.Dto.MbtiDto(m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType), " +
+            "new com.mycom.myapp.naviya.domain.book.dto.BookFavorTotalDto(f.count)) " +
+            "FROM UserRecentBooks ur " +
+            "JOIN ur.book b " +
+            "LEFT JOIN b.bookMbti bm " +
+            "LEFT JOIN bm.mbti m " +
+            "LEFT JOIN BookFavorTotal f ON f.book.bookId = b.bookId " +
+            "WHERE ur.child.childId = :childId " +  // 특정 child_id를 기준으로 필터링
+            "GROUP BY b.bookId, b.title, b.summary, b.recommendedAge, b.publisher, " +
+            "b.author, b.createdAt, b.fullStory, b.bookImage, b.categoryCode, " +
+            "m.mbtiId, m.eiType, m.snType, m.tfType, m.jpType, f.count " +
+            "ORDER BY b.createdAt DESC")  // createdAt DESC로 정렬
+    List<BookDto> findBooksByChildIdOrderByCreatedAtDesc(@Param("childId") Long childId);
+}

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/service/BookSerive.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/service/BookSerive.java
@@ -2,14 +2,15 @@ package com.mycom.myapp.naviya.domain.book.service;
 
 import com.mycom.myapp.naviya.domain.book.dto.BookDto;
 import com.mycom.myapp.naviya.domain.book.dto.BookResultDto;
-/*
+
 public interface BookSerive {
     BookResultDto delBook(Long bookId);
-    BookResultDto detailBook(BookDto bookDto);
+    BookResultDto detailBook(Long bookId);
     BookResultDto listBook();
     BookResultDto updateBook(BookDto bookDto);
     BookResultDto insertBook(BookDto bookDto);
     BookResultDto listbookOrderByCreateDate();
     BookResultDto listBookChildFavor(long ChildId);
     BookResultDto listBookFavorCount();
-}*/
+    BookResultDto listBookChildRecntRead(long ChildId);
+}

--- a/src/main/java/com/mycom/myapp/naviya/domain/book/service/BookServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/book/service/BookServiceImpl.java
@@ -1,15 +1,25 @@
 package com.mycom.myapp.naviya.domain.book.service;
-/*import com.mycom.myapp.naviya.domain.book.entity.Book;
+import com.mycom.myapp.naviya.domain.book.dto.BookFavorTotalDto;
+import com.mycom.myapp.naviya.domain.book.entity.Book;
 import com.mycom.myapp.naviya.domain.book.dto.BookDto;
 import com.mycom.myapp.naviya.domain.book.dto.BookResultDto;
+import com.mycom.myapp.naviya.domain.book.entity.BookFavorTotal;
+import com.mycom.myapp.naviya.domain.book.entity.BookMbti;
+import com.mycom.myapp.naviya.domain.book.repository.BookFavorTotalRepository;
+import com.mycom.myapp.naviya.domain.book.repository.BookMbtiRepository;
 import com.mycom.myapp.naviya.domain.book.repository.BookRepository;
 import com.mycom.myapp.naviya.domain.child.repository.ChildBookLikeRepository;
+import com.mycom.myapp.naviya.global.mbti.Dto.MbtiDto;
 import com.mycom.myapp.naviya.global.mbti.entity.Mbti;
+import com.mycom.myapp.naviya.global.mbti.repository.MbtiRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,11 +27,24 @@ public class BookServiceImpl implements BookSerive {
 
     private final BookRepository bookRepository;
     private final ChildBookLikeRepository childBookLikeRepository;
+    private final MbtiRepository mbtiRepository;
+    private final BookFavorTotalRepository bookFavorTotalRepository;
+    private final BookMbtiRepository bookMbtiRepository;
+
+    /*삭제순서 to 유성,정슈선
+    연관관계 수정으로 book->bookmbti->mbti 한 방에 삭제
+
+    Book (부모)↔ BookMbti (자식) ↔ Mbti (부모)
+     book에  cascaed ->bookmbti 자식에서 -> mbti에게 cascaed으로
+    일대일 양방향에서 자식이 부모에게 casecaed 걸 수 있음
+    기술적으로 가능은함
+    우리는 일부로 childmbti와 bookmbti를 동시에 사용하기 때문에 자식에게 casecade를 걸어도 무방
+      */
     @Override
+    @Transactional
     public BookResultDto delBook(Long bookId) {
         BookResultDto bookResultDto = new BookResultDto();
-        try {
-            bookRepository.deleteById(bookId);
+        try {bookRepository.deleteById(bookId);
             bookResultDto.setSuccess("success");
         }catch(Exception e) {
             e.printStackTrace();
@@ -29,36 +52,125 @@ public class BookServiceImpl implements BookSerive {
         }
         return bookResultDto;
     }
-
+    //들어갈때 storgesession에 넣고 들어가면되지 않나하는 생각이 들어
+    //솔직히 있어야되는지 의문이지만 혹시 몰라 만들어놓습니다 to 정유선
+    //어차피 자세히보는건 굳이 dto쿼리로 안묶어도 될 것 같아서 필요할 것 같으면 바꿔주세용
     @Override
-    public BookResultDto detailBook(BookDto bookDto) {
-        return null;
-    }
-
-    @Override
-    public BookResultDto listBook() {
-
+    public BookResultDto detailBook(Long bookId) {
         // BookRepository의 findAll() 메서드를 통해 모든 Book을 가져옴
-        List<Book> books =bookRepository.findAll();
-        List<BookDto> bookDtos = new ArrayList<>();
-        for (Book book : books) {
-            Mbti mbti= new Mbti();
-            BookDto bookDto = new BookDto();
+
+        BookResultDto bookResultDto = new BookResultDto();
+        try {
+            Book book =bookRepository.findBybookId(bookId);
+            BookDto bookDto =new BookDto();
             bookDto.setBookId(book.getBookId());
             bookDto.setTitle(book.getTitle());
             bookDto.setAuthor(book.getAuthor());
+            bookDto.setBookImage(book.getBookImage());
             bookDto.setPublisher(book.getPublisher());
             bookDto.setSummary(book.getSummary());
             bookDto.setRecommendedAge(book.getRecommendedAge());
-            bookDtos.add(bookDto);
+            bookDto.setCategory(book.getCategoryCode());
+            bookDto.setFullStory(book.getFullStory());
+            List<BookDto>tempDto = new ArrayList<>();
+            tempDto.add(bookDto);
+            bookResultDto.setBooks(tempDto);  // Book 리스트를 BookResultDto에 설정
+            bookResultDto.setSuccess("success");
+            return bookResultDto;
+
+        } catch (EntityNotFoundException e) {
+            bookResultDto.setSuccess("fail");
+            System.err.println(e.getMessage());
+            return bookResultDto;
+        } catch (Exception e) {
+            // 다른 예외 처리 로직
+            bookResultDto.setSuccess("fail");
+            System.err.println("An unexpected error book detail 발생: " + e.getMessage());
+            return bookResultDto;
         }
-        // DTO에 가져온 책 목록을 담음
-        BookResultDto bookResultDto = new BookResultDto();
-        bookResultDto.setBooks(bookDtos);  // Book 리스트를 BookResultDto에 설정
-        bookResultDto.setSuccess("success");
-        return bookResultDto;
     }
 
+    //to 유성 일단 서비스에서는 mbti 값 그대로 내리고 프론트  or 컨트롤러에서 추가 구현 및 조정 생각하고 구현해놨음
+    //추후 구현방식 협의 후 수정 가능
+    //일대일 관계에서는 lazy를 걸어도 eager로 적용되어
+    //n+1 이슈로 밀고 dto쿼리로 바꿨음
+    @Override
+    public BookResultDto listBook() {
+        BookResultDto bookResultDto=new BookResultDto();
+        try{
+            List<BookDto> bookDto = bookRepository.findAllBookDto();
+            bookResultDto.setBooks(bookDto);  // Book 리스트를 BookResultDto에 설정
+            bookResultDto.setSuccess("success");
+            return bookResultDto;
+        }
+        catch(Exception e){
+            e.printStackTrace();
+            bookResultDto.setSuccess("fail");
+            return bookResultDto;
+        }
+    }
+
+    @Override
+    public BookResultDto listbookOrderByCreateDate() {
+        BookResultDto bookResultDto=new BookResultDto();
+        try{
+            List<BookDto> bookDto = bookRepository.findBookDtoDescCreateDate();
+            bookResultDto.setBooks(bookDto);  // Book 리스트를 BookResultDto에 설정
+            bookResultDto.setSuccess("success");
+            return bookResultDto;
+        }
+        catch(Exception e){
+            e.printStackTrace();
+            bookResultDto.setSuccess("fail");
+            return bookResultDto;
+        }
+    }
+
+    @Override
+    public BookResultDto listBookChildFavor(long ChildId) {
+        BookResultDto bookResultDto=new BookResultDto();
+        try{
+            List<BookDto> bookDto = bookRepository.findBooksByChildId(ChildId);
+            bookResultDto.setBooks(bookDto);  // Book 리스트를 BookResultDto에 설정
+            bookResultDto.setSuccess("success");
+            return bookResultDto;
+        }
+        catch(Exception e){
+            e.printStackTrace();
+            bookResultDto.setSuccess("fail");
+            return bookResultDto;
+        }
+    }
+
+    @Override
+    public BookResultDto listBookFavorCount() {
+        BookResultDto bookResultDto=new BookResultDto();
+        try{
+            List<BookDto> bookDto = bookRepository.findBookDescBookFavor();
+            bookResultDto.setBooks(bookDto);  // Book 리스트를 BookResultDto에 설정
+            bookResultDto.setSuccess("success");
+            return bookResultDto;
+        }
+        catch(Exception e){
+            e.printStackTrace();
+            bookResultDto.setSuccess("fail");
+            return bookResultDto;
+        }
+    }
+    public BookResultDto listBookChildRecntRead(long ChildId) {
+        BookResultDto bookResultDto=new BookResultDto();
+        try{
+        List<BookDto> bookDto = bookRepository.findBooksByChildIdOrderByCreatedAtDesc(ChildId);
+        bookResultDto.setBooks(bookDto);  // Book 리스트를 BookResultDto에 설정
+        bookResultDto.setSuccess("success");
+        return bookResultDto;
+        }
+        catch(Exception e){
+            e.printStackTrace();
+            bookResultDto.setSuccess("fail");
+            return bookResultDto;
+        }
+    }
     @Override
     public BookResultDto updateBook(BookDto bookDto) {
         return null;
@@ -69,97 +181,4 @@ public class BookServiceImpl implements BookSerive {
         return null;
     }
 
-    @Override
-    public BookResultDto listbookOrderByCreateDate() {
-        List<Book> books =bookRepository.findAllByOrderByCreateDateDesc();
-        List<BookDto> bookDtos = new ArrayList<>();
-        for (Book book : books) {
-            BookDto bookDto = new BookDto();
-            bookDto.setBookId(book.getBookId());
-            bookDto.setTitle(book.getTitle());
-            bookDto.setAuthor(book.getAuthor());
-            bookDto.setCount(book.getCount());
-            CategoryBookDto categoryBookDto = new CategoryBookDto();
-            categoryBookDto.setCategoryName(book.getCategory().getCategoryName());
-            categoryBookDto.setCategoryId(book.getCategory().getCategoryId());
-            bookDto.setCategoryBookDto(categoryBookDto);
-            bookDto.setPublisher(book.getPublisher());
-            bookDto.setEiType(book.getEiType());
-            bookDto.setSnType(book.getSnType());
-            bookDto.setTfType(book.getTfType());
-            bookDto.setJpType(book.getJpType());
-            bookDto.setSummary(book.getSummary());
-            bookDto.setCreateDate(book.getCreateDate());
-            bookDto.setRecommendedAge(book.getRecommendedAge());
-            bookDtos.add(bookDto);
-        }
-        // DTO에 가져온 책 목록을 담음
-        BookResultDto bookResultDto = new BookResultDto();
-        bookResultDto.setBooks(bookDtos);  // Book 리스트를 BookResultDto에 설정
-        bookResultDto.setSuccess("success");
-        return bookResultDto;
-    }
-
-    @Override
-    public BookResultDto listBookChildFavor(long ChildId) {
-        List<Book> books =childBookLikeRepository.findBooksByChildId(ChildId);
-        List<BookDto> bookDtos = new ArrayList<>();
-        for (Book book : books) {
-            BookDto bookDto = new BookDto();
-            bookDto.setBookId(book.getBookId());
-            bookDto.setTitle(book.getTitle());
-            bookDto.setAuthor(book.getAuthor());
-            bookDto.setCount(book.getCount());
-            CategoryBookDto categoryBookDto = new CategoryBookDto();
-            categoryBookDto.setCategoryName(book.getCategory().getCategoryName());
-            categoryBookDto.setCategoryId(book.getCategory().getCategoryId());
-            bookDto.setCategoryBookDto(categoryBookDto);
-            bookDto.setPublisher(book.getPublisher());
-            bookDto.setEiType(book.getEiType());
-            bookDto.setSnType(book.getSnType());
-            bookDto.setTfType(book.getTfType());
-            bookDto.setJpType(book.getJpType());
-            bookDto.setSummary(book.getSummary());
-            bookDto.setCreateDate(book.getCreateDate());
-            bookDto.setRecommendedAge(book.getRecommendedAge());
-            bookDtos.add(bookDto);
-        }
-        // DTO에 가져온 책 목록을 담음
-        BookResultDto bookResultDto = new BookResultDto();
-        bookResultDto.setBooks(bookDtos);  // Book 리스트를 BookResultDto에 설정
-        bookResultDto.setSuccess("success");
-        return bookResultDto;
-    }
-
-    @Override
-    public BookResultDto listBookFavorCount() {
-        List<Book> books =bookRepository.findAllByOrderByCountDesc();
-        List<BookDto> bookDtos = new ArrayList<>();
-        for (Book book : books) {
-            BookDto bookDto = new BookDto();
-            bookDto.setBookId(book.getBookId());
-            bookDto.setTitle(book.getTitle());
-            bookDto.setAuthor(book.getAuthor());
-            bookDto.setCount(book.getCount());
-            CategoryBookDto categoryBookDto = new CategoryBookDto();
-            categoryBookDto.setCategoryName(book.getCategory().getCategoryName());
-            categoryBookDto.setCategoryId(book.getCategory().getCategoryId());
-            bookDto.setCategoryBookDto(categoryBookDto);
-            bookDto.setPublisher(book.getPublisher());
-            bookDto.setEiType(book.getEiType());
-            bookDto.setSnType(book.getSnType());
-            bookDto.setTfType(book.getTfType());
-            bookDto.setJpType(book.getJpType());
-            bookDto.setSummary(book.getSummary());
-            bookDto.setCreateDate(book.getCreateDate());
-            bookDto.setRecommendedAge(book.getRecommendedAge());
-            bookDtos.add(bookDto);
-        }
-        // DTO에 가져온 책 목록을 담음
-        BookResultDto bookResultDto = new BookResultDto();
-        bookResultDto.setBooks(bookDtos);  // Book 리스트를 BookResultDto에 설정
-        bookResultDto.setSuccess("success");
-        return bookResultDto;
-    }
 }
-*/

--- a/src/main/java/com/mycom/myapp/naviya/domain/child/entity/ChildBookDislike.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/child/entity/ChildBookDislike.java
@@ -16,7 +16,7 @@ public class ChildBookDislike {
     @JoinColumn(name = "child_id", nullable = false)
     private Child child;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 

--- a/src/main/java/com/mycom/myapp/naviya/domain/child/entity/ChildBookLike.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/child/entity/ChildBookLike.java
@@ -17,7 +17,7 @@ public class ChildBookLike {
     @JoinColumn(name = "child_id", nullable = false)
     private Child child;
 
-    @OneToOne()
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id", nullable = false)
     private Book book;
 

--- a/src/main/java/com/mycom/myapp/naviya/global/mbti/Dto/MbtiDto.java
+++ b/src/main/java/com/mycom/myapp/naviya/global/mbti/Dto/MbtiDto.java
@@ -1,0 +1,29 @@
+package com.mycom.myapp.naviya.global.mbti.Dto;
+
+import com.mycom.myapp.naviya.domain.book.entity.BookMbti;
+import com.mycom.myapp.naviya.domain.child.entity.ChildMbti;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class MbtiDto {
+
+    private Long mbtiId;
+    private int eiType;
+    private int snType;
+    private int tfType;
+    private int jpType;
+    /*public MbtiDto(){}
+    public MbtiDto(Long mbtiId, int eiType, int snType, int tfType, int jpType) {
+        this.mbtiId = mbtiId;
+        this.eiType = eiType;
+        this.snType = snType;
+        this.tfType = tfType;
+        this.jpType = jpType;
+    }*/
+
+}

--- a/src/main/java/com/mycom/myapp/naviya/global/mbti/Mbti_Name.java
+++ b/src/main/java/com/mycom/myapp/naviya/global/mbti/Mbti_Name.java
@@ -1,0 +1,10 @@
+package com.mycom.myapp.naviya.global.mbti;
+
+//굳이 필요할까 싶은데 혹시 쓸사람 있을까봐
+public enum Mbti_Name {
+    ISTJ, ISFJ, INFJ, INTJ,
+    ISTP, ISFP, INFP, INTP,
+    ESTP, ESFP, ENFP, ENTP,
+    ESTJ, ESFJ, ENFJ, ENTJ;
+
+}

--- a/src/main/java/com/mycom/myapp/naviya/global/mbti/entity/Mbti.java
+++ b/src/main/java/com/mycom/myapp/naviya/global/mbti/entity/Mbti.java
@@ -4,10 +4,12 @@ import com.mycom.myapp.naviya.domain.book.entity.Book;
 import com.mycom.myapp.naviya.domain.book.entity.BookMbti;
 import com.mycom.myapp.naviya.domain.child.entity.ChildMbti;
 import jakarta.persistence.*;
+import lombok.Data;
 
 import java.util.List;
 
 @Entity
+@Data
 @Table(name = "Mbti")
 public class Mbti {
 

--- a/src/main/java/com/mycom/myapp/naviya/global/mbti/repository/MbtiRepository.java
+++ b/src/main/java/com/mycom/myapp/naviya/global/mbti/repository/MbtiRepository.java
@@ -1,0 +1,10 @@
+package com.mycom.myapp.naviya.global.mbti.repository;
+
+import com.mycom.myapp.naviya.global.mbti.entity.Mbti;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MbtiRepository extends JpaRepository<Mbti, Long> {
+
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/-book_crud_adjustment-> dev

## PR 설명
admin book crud erd 바뀐것에 대해  수정,여러종류 erd반영 수정, 최근 아이가 읽은 책 목록 추가,book,bookmbti erd 수정

## ✅ 완료한 기능 명세

- [x] ERD수정에 맞는 도서 기존 CRUD수정
- [x] 아이가 최근 본 도서 목록 불러오기 추가
- [x] book,bookmbti entity 추가 수정
- [x] 기존 좋아요 누른 도서목록,최신도서목록,총좋아요 순 도서목록 erd에 맞게 수정 및 jpa dto쿼리로 모두 수정
- [x] ## 📸 스크린샷
![image](https://github.com/user-attachments/assets/9a29cc45-5abd-45be-bbf2-98ef231f9045)
각 기능 모두 postman으로 검수 

## 고민과 해결과정
다 만들어놓고  수정된 entity로 인해 모두 n+1 문제가 일어나는 것을 발견 
하지만 일대일에선 lazy로 해도 egear로 발생되는 문제 발견 
문제해결-> 대부분의 쿼리 모두 dto 쿼리로 변경 
![image (2)](https://github.com/user-attachments/assets/9a7682c7-afa4-46bc-bd54-a1b42d6da33c)
전
![image](https://github.com/user-attachments/assets/1ae70ab3-c74a-4e97-a1c7-6f0ca36996e9)
후
![image](https://github.com/user-attachments/assets/48567f71-d5cf-44d2-876b-dbb327d23dd8)

참고->https://1-7171771.tistory.com/143

entity  여러 뎊스로 삭제되어야 하는 entity가 삭제되지 않음
->entity 변경 

#반성
자꾸 gpt에 의존하여 고쳐도 정확한 원리를 모르고 대충 기분만 아는식으로 매번 개발을 진행했었음
n+1 문제와 무한호출에 대해서도 제대로 모르고 유성이에게 들어서 알고
onetoone 오너쉽에 대해서도 지민님과 병옥이와 작업하다가 제대로 알았음

좀 더 기록해가며 확실히 개발해야 할 필요성을 느낌