### PR TITLE
[Feat] Quartz Scheduler job제거 기능

### DIFF
--- a/src/main/java/com/mycom/myapp/naviya/domain/child/entity/ChildMbti.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/child/entity/ChildMbti.java
@@ -20,7 +20,7 @@ public class ChildMbti {
     @JoinColumn(name = "child_id", nullable = false)
     private Child child;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "mbti_id", nullable = false)
     private Mbti mbti;
 

--- a/src/main/java/com/mycom/myapp/naviya/domain/child/repository/ChildMbtiRepository.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/child/repository/ChildMbtiRepository.java
@@ -45,4 +45,7 @@ public interface ChildMbtiRepository extends JpaRepository<ChildMbti, Long> {
 
     @Query("SELECT CASE WHEN c.deletedAt IS NULL THEN true ELSE false END FROM ChildMbti c WHERE c.child.childId = :childId")
     Optional<Boolean> isDeletedByChildId(@Param("childId") Long childId);
+
+    @Query("SELECT cm from ChildMbti cm where cm.child = :child AND cm.deletedAt IS NULL")
+    ChildMbti findChildMbtiBycChildAndDeletedAt(@Param("child") Child child);
 }

--- a/src/main/java/com/mycom/myapp/naviya/domain/child/service/ChildMbtiServiceImpl.java
+++ b/src/main/java/com/mycom/myapp/naviya/domain/child/service/ChildMbtiServiceImpl.java
@@ -12,11 +12,9 @@ import com.mycom.myapp.naviya.global.mbti.service.MbtiDiagnosisDataQuartzService
 import com.mycom.myapp.naviya.global.mbti.repository.MbtiRepository;
 import jakarta.servlet.http.HttpSession;
 import lombok.AllArgsConstructor;
-import org.quartz.SchedulerException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,21 +26,21 @@ public class ChildMbtiServiceImpl implements ChildMbtiService {
 
     private final ChildMbtiRepository childMbtiRepository;
 
-    private ChildRepository childRepository;
+    private final ChildRepository childRepository;
 
-    private MbtiRepository mbtiRepository;
+    private final MbtiRepository mbtiRepository;
 
-    private ChildMbtiHistoryRepository childMbtiHistoryRepository;
+    private final ChildMbtiHistoryRepository childMbtiHistoryRepository;
 
-    private ChildBookLikeRepository childBookLikeRepository;
+    private final ChildBookLikeRepository childBookLikeRepository;
 
-    private ChildBookDisLikeRepository childBookDislikeRepository;
+    private final ChildBookDisLikeRepository childBookDislikeRepository;
 
-    private ChildFavorCategoryRepository childFavorCategoryRepository;
+    private final ChildFavorCategoryRepository childFavorCategoryRepository;
 
-    private MbtiDiagnosisDataQuartzService mbtiDiagnosisDataQuartzService;
+    private final MbtiDiagnosisDataQuartzService mbtiDiagnosisDataQuartzService;
 
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
     /**
      * 자녀의 MBTI 성향을 진단하고 저장하는 메서드 (ChildMbti와 ChildMbtiHistory에 저장).
@@ -56,7 +54,7 @@ public class ChildMbtiServiceImpl implements ChildMbtiService {
         Child child = childRepository.findById(childId)
                 .orElseThrow(() -> new RuntimeException("아이를 찾을 수 없습니다."));
 
-        if (child.getCodeMbti() != null){
+        if (childMbtiRepository.findChildMbtiBycChildAndDeletedAt(child) != null){
             // 기존 데이터 처리: ChildMbti와 ChildMbtiHistory의 deletedAt 필드 업데이트(논리적 삭제)
             updateDeletedAtForExistingRecords(child);
         }
@@ -98,12 +96,8 @@ public class ChildMbtiServiceImpl implements ChildMbtiService {
 
         childRepository.save(child);
         // 스케줄러를 이용하여 30일 뒤에 실제 삭제 수행
-        try {
-            mbtiDiagnosisDataQuartzService.
-                    scheduleChildDeletion(child, futureLocalDateTime);
-        } catch (SchedulerException e) {
-            throw new RuntimeException("Failed to schedule child deletion", e);
-        }
+        mbtiDiagnosisDataQuartzService.
+                scheduleChildDeletion(child, futureLocalDateTime);
     }
 
     /**

--- a/src/main/java/com/mycom/myapp/naviya/global/mbti/entity/Mbti.java
+++ b/src/main/java/com/mycom/myapp/naviya/global/mbti/entity/Mbti.java
@@ -1,12 +1,10 @@
 package com.mycom.myapp.naviya.global.mbti.entity;
 
-import com.mycom.myapp.naviya.domain.book.entity.Book;
-import com.mycom.myapp.naviya.domain.book.entity.BookMbti;
 import com.mycom.myapp.naviya.domain.child.entity.ChildMbti;
+import com.mycom.myapp.naviya.domain.book.entity.BookMbti;
 import jakarta.persistence.*;
 import lombok.Data;
 
-import java.util.List;
 
 @Entity
 @Data
@@ -30,12 +28,50 @@ public class Mbti {
     @Column(name = "jp_type")
     private int jpType;
 
+    @Transient
+    private int oldEiType;
+
+    @Transient
+    private int oldSnType;
+
+    @Transient
+    private int oldTfType;
+
+    @Transient
+    private int oldJpType;
+
     @OneToOne(mappedBy = "mbti")
     private ChildMbti childMbtis;
 
     @OneToOne(mappedBy = "mbti")
     private BookMbti bookMbti;
 
+    // 엔티티가 로드될 때 기존 점수를 저장하고 클램핑 적용
+    @PostLoad
+    private void saveOldScores() {
+        // 점수를 -100에서 100 사이로 제한
+        clampScores();
+
+        this.oldEiType = this.eiType;
+        this.oldSnType = this.snType;
+        this.oldTfType = this.tfType;
+        this.oldJpType = this.jpType;
+    }
+
+    @PreUpdate
+    private void saveNewScores(){
+        clampScores();
+    }
+
+    // 점수를 -100에서 100 사이로 제한하는 메서드
+    private void clampScores() {
+        this.eiType = Math.max(-100, Math.min(100, this.eiType));
+        this.snType = Math.max(-100, Math.min(100, this.snType));
+        this.tfType = Math.max(-100, Math.min(100, this.tfType));
+        this.jpType = Math.max(-100, Math.min(100, this.jpType));
+    }
+
     // Getters and Setters
 }
+
 

--- a/src/main/java/com/mycom/myapp/naviya/global/mbti/service/MbtiDiagnosisDataQuartzService.java
+++ b/src/main/java/com/mycom/myapp/naviya/global/mbti/service/MbtiDiagnosisDataQuartzService.java
@@ -1,10 +1,11 @@
 package com.mycom.myapp.naviya.global.mbti.service;
 
 import com.mycom.myapp.naviya.domain.child.entity.Child;
-import com.mycom.myapp.naviya.domain.child.repository.*;
 import com.mycom.myapp.naviya.global.scheduler.ChildDeletionJob;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.quartz.*;
+import org.quartz.impl.matchers.GroupMatcher;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -13,6 +14,7 @@ import java.util.Date;
 
 @Service
 @AllArgsConstructor
+@Slf4j
 public class MbtiDiagnosisDataQuartzService {
 
     private final Scheduler scheduler;
@@ -22,24 +24,61 @@ public class MbtiDiagnosisDataQuartzService {
      * @param child 자녀 엔티티
      * @param deleteDate 삭제가 예정된 날짜
      */
-    public void scheduleChildDeletion(Child child, LocalDateTime deleteDate) throws SchedulerException {
-        // LocalDateTime을 Date 객체로 변환하여 Quartz에서 사용할 수 있도록 함
-        Date deleteAt = Date.from(deleteDate.atZone(ZoneId.systemDefault()).toInstant());
+    public void scheduleChildDeletion(Child child, LocalDateTime deleteDate) {
+        synchronized (this) {
+            try {
+                // LocalDateTime을 Date 객체로 변환하여 Quartz에서 사용할 수 있도록 함
+                Date deleteAt = Date.from(deleteDate.atZone(ZoneId.systemDefault()).toInstant());
+                String jobName = "child-" + child.getChildId().toString() + "-" + deleteDate;
+                JobKey jobKey = new JobKey(jobName, "childDeletionJob");
 
-        // JobDetail 생성: 자녀 삭제 작업에 대한 정보 포함
-        JobDetail jobDetail = JobBuilder.newJob(ChildDeletionJob.class)
-                .withIdentity("childDeletionJob", child.getChildId().toString()+" "+ deleteDate) // Job 이름에 자녀 ID 사용
-                .usingJobData("child", child.getChildId()) // Job에 필요한 데이터 설정 (childId)
-                .usingJobData("deleteDate", deleteDate.toString()) // Job에 필요한 데이터 설정 (deleteDate)
-                .build();
+                // 기존에 동일한 Job이 존재하는지 확인하고, 있을 경우 삭제
+                if (scheduler.checkExists(jobKey)) {
+                    scheduler.deleteJob(jobKey);
+                    log.info("기존 Job이 삭제되었습니다: {}", jobKey);
+                }
 
-        // 트리거 생성: 특정 시점에 Job을 실행하도록 설정
-        Trigger trigger = TriggerBuilder.newTrigger()
-                .withIdentity("childDeletionTrigger", child.getChildId().toString()+" "+ deleteDate) // 트리거 이름에 자녀 ID 사용
-                .startAt(deleteAt) // 지정된 날짜에 Job 실행
-                .build();
+                // JobDetail 생성: 자녀 삭제 작업에 대한 정보 포함
+                JobDetail jobDetail = JobBuilder.newJob(ChildDeletionJob.class)
+                        .withIdentity(jobKey) // Job 이름에 자녀 ID 사용
+                        .usingJobData("child", child.getChildId()) // Job에 필요한 데이터 설정 (childId)
+                        .usingJobData("deleteDate", deleteDate.toString()) // Job에 필요한 데이터 설정 (deleteDate)
+                        .build();
 
-        // 스케줄러에 Job과 트리거를 등록하여 예약 작업 수행
-        scheduler.scheduleJob(jobDetail, trigger);
+                // 트리거 생성: 특정 시점에 Job을 실행하도록 설정
+                Trigger trigger = TriggerBuilder.newTrigger()
+                        .withIdentity(child.getChildId().toString() + " " + deleteDate, "childDeletionTrigger") // 트리거 이름에 자녀 ID 사용
+                        .startAt(deleteAt) // 지정된 날짜에 Job 실행
+                        .build();
+
+                // 스케줄러에 Job과 트리거를 등록하여 예약 작업 수행
+                scheduler.scheduleJob(jobDetail, trigger);
+                log.info("Child 삭제 작업이 스케줄되었습니다: childId={}, deleteDate={}", child.getChildId(), deleteDate);
+            } catch (SchedulerException e) {
+                log.error("Child 삭제 작업 스케줄링 실패: childId={}, deleteDate={}", child.getChildId(), deleteDate, e);
+                throw new RuntimeException("Failed to schedule child deletion", e);
+            }
+        }
+    }
+
+    /**
+     * 특정 childId에 관련된 모든 Job 삭제
+     * @param childId 자녀 ID
+     */
+    public void deleteAllJobsForChild(Long childId) {
+        try {
+            // "childDeletionJob" 그룹 내 모든 JobKey 순회
+            for (JobKey jobKey : scheduler.getJobKeys(GroupMatcher.jobGroupEquals("childDeletionJob"))) {
+                // jobName이 "child-{childId}-" 형식을 사용해 정확히 일치하는지 확인
+                if (jobKey.getName().startsWith("child-" + childId + "-")) {
+                    // 해당 Job 삭제
+                    scheduler.deleteJob(jobKey);
+                    log.info("Job이 삭제되었습니다: {}", jobKey);
+                }
+            }
+        } catch (SchedulerException e) {
+            log.error("예약된 삭제 작업 취소 중 오류 발생: childId={}", childId, e);
+            throw new RuntimeException("예약된 삭제 작업 취소 중 오류 발생", e);
+        }
     }
 }

--- a/src/main/resources/static/newNavtoggle.html
+++ b/src/main/resources/static/newNavtoggle.html
@@ -53,6 +53,7 @@
   <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
   <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
   <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+  <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
   <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
   <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
   <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/BookCategoryHtml.html
+++ b/src/main/resources/templates/BookCategoryHtml.html
@@ -172,6 +172,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="/ChildRecentReadBook"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="/BookCategoryHtml"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/BookReadPage.html
+++ b/src/main/resources/templates/BookReadPage.html
@@ -165,6 +165,7 @@
   <a href="/children/select">아이 프로필 변경</a>
   <a href="/children/page">아이 정보 수정</a>
   <a href="/userpage">계정보기</a>
+  <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
   <a href="#">최근 책 보기</a>
   <a href="/ChildFavorBookList.html">좋아요 누른 책 보기</a>
   <a href="#">카테고리 별 책보기</a>

--- a/src/main/resources/templates/ChildFavorBookList.html
+++ b/src/main/resources/templates/ChildFavorBookList.html
@@ -149,6 +149,7 @@
   <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
   <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
   <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+  <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
   <a href="/ChildRecentReadBook"><i class="fas fa-history"></i> 최근 책 보기</a>
   <a href="/ChildFavorBookList"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
   <a href="/BookCategoryHtml"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/ChildRecentReadBook.html
+++ b/src/main/resources/templates/ChildRecentReadBook.html
@@ -151,6 +151,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="/ChildRecentReadBook"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="/BookCategoryHtml"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/childAdd.html
+++ b/src/main/resources/templates/childAdd.html
@@ -211,6 +211,7 @@
   <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
   <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
   <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+  <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
   <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
   <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
   <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/childAddAskMbti.html
+++ b/src/main/resources/templates/childAddAskMbti.html
@@ -104,6 +104,7 @@
   <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
   <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
   <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+  <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
   <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
   <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
   <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/childMBTIResult.html
+++ b/src/main/resources/templates/childMBTIResult.html
@@ -91,7 +91,7 @@
             position: relative;
         }
         .no-data-icon::after {
-            content: "진단을 하지 않으면 아이의 성향을 새롭게 발견할 기회가 있어요. 아이와 함께 진단 과정을 즐겨보세요!";
+            content: "진단을 통해 아이의 성향을 발견해보세요!.";
             position: absolute;
             top: 100%;
             left: 50%;
@@ -412,6 +412,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/childPage.html
+++ b/src/main/resources/templates/childPage.html
@@ -235,6 +235,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/childSelectPage.html
+++ b/src/main/resources/templates/childSelectPage.html
@@ -201,6 +201,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/childUpdate.html
+++ b/src/main/resources/templates/childUpdate.html
@@ -227,6 +227,7 @@
   <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
   <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
   <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+  <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
   <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
   <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
   <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/diagnosisForm.html
+++ b/src/main/resources/templates/diagnosisForm.html
@@ -175,6 +175,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>
@@ -341,12 +342,15 @@
     }
 
     function checkResults() {
+        const resultButton = document.querySelector('#end-screen button');
+        resultButton.disabled = true; // 버튼 비활성화
+
         fetch(`/api/mbti/diagnose`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 eiScore: answers[0],
-                snScore:  answers[1],
+                snScore: answers[1],
                 tfScore: answers[2],
                 jpScore: answers[3]
             })
@@ -366,6 +370,7 @@
             .catch(error => {
                 console.error("오류 발생:", error);
                 alert('진단 결과를 전송하는 데 실패했습니다.');
+                resultButton.disabled = false; // 실패 시 버튼을 다시 활성화
             });
     }
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -313,6 +313,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="/ChildRecentReadBook"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="/BookCategoryHtml"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/lotteryForm.html
+++ b/src/main/resources/templates/lotteryForm.html
@@ -298,6 +298,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/mbtiHistory.html
+++ b/src/main/resources/templates/mbtiHistory.html
@@ -233,6 +233,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/search.html
+++ b/src/main/resources/templates/search.html
@@ -221,6 +221,7 @@
   <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
   <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
   <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+  <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
   <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
   <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
   <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>

--- a/src/main/resources/templates/userPage.html
+++ b/src/main/resources/templates/userPage.html
@@ -181,6 +181,7 @@
     <a href="/children/select"><i class="fas fa-child"></i> 아이 프로필 변경</a>
     <a href="/children/page"><i class="fas fa-edit"></i> 아이 정보 수정</a>
     <a href="/userpage"><i class="fas fa-user"></i> 계정보기</a>
+    <a href="/children/childMBTIResult"><i class="fas fa-user-circle"></i> 아이 성향 확인하기</a>
     <a href="#"><i class="fas fa-history"></i> 최근 책 보기</a>
     <a href="/ChildFavorBookList.html"><i class="fas fa-heart"></i> 좋아요 누른 책 보기</a>
     <a href="#"><i class="fas fa-tags"></i> 카테고리 별 책보기</a>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat-Quartz_job_delete -> dev

## PR 설명
논리적 삭제를 위해 Quartz에 설정해둔 job(진단 데이터 + 기타 데이터 delete )을 제거기능을 추가하여 자녀 삭제 기능에 의해 예약이 되어있는 (delete될) 데이터가 삭제되는 경우 job 실행 방지하고자 하였다.

작업 상세 내용
## ✅ 완료한 기능 명세

- [x] Quartz job제거 기능
- [x] 사이드바에 "아이 성향 확인하기" 추가 

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/4cad6bb6-53a0-47b4-b2e0-c084e0aab478)
